### PR TITLE
[#1] Initialize repository with README and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,63 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Build output
+dist/
+build/
+out/
+.next/
+.nuxt/
+.svelte-kit/
+
+# Environment files
+.env
+.env.local
+.env.*.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Runtime / cache
+.cache/
+.parcel-cache/
+.turbo/
+.eslintcache
+
+# Package manager lockfiles (keep one; ignore the others as needed)
+# Uncomment the lockfile your project does NOT use:
+# package-lock.json
+# yarn.lock
+# pnpm-lock.yaml
+
+# OS junk
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Editor / IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Testing
+coverage/
+.nyc_output/
+
+# Python (if any tooling uses it)
+__pycache__/
+*.py[cod]
+*.pyo
+.venv/
+venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # Capsule
+
+Capsule is a personal memory and knowledge management app that helps you capture, organize, and revisit the moments, ideas, and information that matter to you.
+
+## Product Description
+
+Capsule lets you store short notes, links, images, and reflections in one place — your personal digital capsule. Think of it as a private, searchable journal meets bookmarking tool, built for people who want to remember more of what they encounter each day.
+
+## Core MVP Idea
+
+A simple web app where users can create an account, add "capsules" (small pieces of content with a title, body, optional tags, and a date), browse their history, and search across everything they've saved.
+
+## Planned Main Features
+
+- User authentication (sign up, log in, log out)
+- Create, read, update, and delete capsules
+- Tag-based organization
+- Full-text search across capsules
+- Timeline / feed view of past entries
+- Responsive web UI
+
+## Getting Started
+
+> The app has not been scaffolded yet. Setup instructions will be added here once the initial project structure is in place.
+
+```
+# placeholder — check back after initial scaffold commit
+```
+
+## Development Roadmap
+
+> Detailed milestones will be added as the project progresses.
+
+- [ ] Repository setup and tooling (this issue)
+- [ ] Project scaffold (backend + frontend framework choice)
+- [ ] Database schema and migrations
+- [ ] Authentication flow
+- [ ] Core capsule CRUD API
+- [ ] Frontend UI components
+- [ ] Search and filtering
+- [ ] Deployment and CI/CD


### PR DESCRIPTION
## Summary

- Replaces the stub `README.md` with a full project overview: product description, core MVP idea, planned features, placeholder setup instructions, and a development roadmap
- Adds a `.gitignore` covering `node_modules`, build output directories (`dist/`, `build/`, `.next/`, etc.), environment files (`.env*`), logs, OS junk (`.DS_Store`, `Thumbs.db`), and editor files (`.vscode/`, `.idea/`)

## Test plan

- [ ] Verify `README.md` renders correctly on GitHub with all required sections
- [ ] Verify `.gitignore` entries cover the patterns described in the issue

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)