### PR TITLE
[#22] Design capsule data model and access rules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 # Application
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
+# Local development only: when true outside production, API routes accept
+# x-user-id as the acting user until real session/JWT auth is wired in.
+CAPSULE_ENABLE_DEV_USER_HEADER=false
+
 # Add your environment variables below
 # Copy this file to .env.local and fill in the values

--- a/app/api/capsules/[id]/open/route.ts
+++ b/app/api/capsules/[id]/open/route.ts
@@ -13,7 +13,7 @@ export async function POST(request: Request, context: RouteContext) {
   const requesterId = requesterIdFromHeaders(request.headers);
 
   if (!requesterId) {
-    return NextResponse.json({ error: "x-user-id header is required" }, { status: 401 });
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const { id } = await context.params;

--- a/app/api/capsules/[id]/open/route.ts
+++ b/app/api/capsules/[id]/open/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { CapsuleAccessError } from "@/lib/capsules/model";
+import { requesterIdFromHeaders, toCapsuleResponse } from "@/lib/capsules/http";
+import { markCapsuleOpened } from "@/lib/capsules/repository";
+
+type RouteContext = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function POST(request: Request, context: RouteContext) {
+  const requesterId = requesterIdFromHeaders(request.headers);
+
+  if (!requesterId) {
+    return NextResponse.json({ error: "x-user-id header is required" }, { status: 401 });
+  }
+
+  const { id } = await context.params;
+
+  try {
+    const capsule = markCapsuleOpened(id, requesterId);
+
+    if (!capsule) {
+      return NextResponse.json({ error: "capsule not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ capsule: toCapsuleResponse(capsule, requesterId) });
+  } catch (error) {
+    if (error instanceof CapsuleAccessError) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
+    }
+
+    throw error;
+  }
+}

--- a/app/api/capsules/[id]/route.ts
+++ b/app/api/capsules/[id]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { canReadCapsuleMetadata } from "@/lib/capsules/model";
+import { requesterIdFromHeaders, toCapsuleResponse } from "@/lib/capsules/http";
+import { getCapsuleById } from "@/lib/capsules/repository";
+
+type RouteContext = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function GET(request: Request, context: RouteContext) {
+  const requesterId = requesterIdFromHeaders(request.headers);
+  const { id } = await context.params;
+  const capsule = getCapsuleById(id);
+
+  if (!capsule || !canReadCapsuleMetadata(capsule, { requesterId })) {
+    return NextResponse.json({ error: "capsule not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ capsule: toCapsuleResponse(capsule, requesterId) });
+}

--- a/app/api/capsules/route.ts
+++ b/app/api/capsules/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { createCapsule, listCapsules } from "@/lib/capsules/repository";
+import { CapsuleValidationError } from "@/lib/capsules/model";
+import {
+  filterReadableCapsules,
+  parseCapsuleCreateBody,
+  requesterIdFromHeaders,
+  toCapsuleResponse,
+} from "@/lib/capsules/http";
+
+export async function GET(request: Request) {
+  const requesterId = requesterIdFromHeaders(request.headers);
+  const capsules = filterReadableCapsules(listCapsules(), requesterId).map((capsule) =>
+    toCapsuleResponse(capsule, requesterId),
+  );
+
+  return NextResponse.json({ capsules });
+}
+
+export async function POST(request: Request) {
+  const requesterId = requesterIdFromHeaders(request.headers);
+
+  if (!requesterId) {
+    return NextResponse.json({ error: "x-user-id header is required" }, { status: 401 });
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "request body must be valid JSON" }, { status: 400 });
+  }
+
+  try {
+    const capsule = createCapsule(parseCapsuleCreateBody(payload as Record<string, unknown>, requesterId));
+    return NextResponse.json({ capsule: toCapsuleResponse(capsule, requesterId) }, { status: 201 });
+  } catch (error) {
+    if (error instanceof CapsuleValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    throw error;
+  }
+}

--- a/app/api/capsules/route.ts
+++ b/app/api/capsules/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: Request) {
   const requesterId = requesterIdFromHeaders(request.headers);
 
   if (!requesterId) {
-    return NextResponse.json({ error: "x-user-id header is required" }, { status: 401 });
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   let payload: unknown;

--- a/db/migrations/0001_create_capsules.sql
+++ b/db/migrations/0001_create_capsules.sql
@@ -1,0 +1,35 @@
+CREATE TABLE capsules (
+  id TEXT PRIMARY KEY,
+  owner_id TEXT NOT NULL,
+  title TEXT NOT NULL CHECK (length(trim(title)) BETWEEN 1 AND 120),
+  body TEXT NOT NULL CHECK (length(trim(body)) BETWEEN 1 AND 10000),
+  visibility TEXT NOT NULL DEFAULT 'private' CHECK (visibility IN ('private', 'public')),
+  open_at TIMESTAMPTZ NOT NULL,
+  opened_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  media_count INTEGER NOT NULL DEFAULT 0 CHECK (media_count BETWEEN 0 AND 12),
+  media_total_bytes INTEGER NOT NULL DEFAULT 0 CHECK (media_total_bytes BETWEEN 0 AND 104857600),
+  CONSTRAINT capsules_opened_after_open_at CHECK (opened_at IS NULL OR opened_at >= open_at),
+  CONSTRAINT capsules_open_at_after_created_at CHECK (open_at > created_at)
+);
+
+CREATE INDEX capsules_owner_id_created_at_idx ON capsules (owner_id, created_at DESC);
+CREATE INDEX capsules_public_opened_idx ON capsules (visibility, opened_at)
+  WHERE visibility = 'public' AND opened_at IS NOT NULL;
+CREATE INDEX capsules_open_at_locked_idx ON capsules (open_at)
+  WHERE opened_at IS NULL;
+
+CREATE TABLE capsule_media (
+  id TEXT PRIMARY KEY,
+  capsule_id TEXT NOT NULL REFERENCES capsules (id) ON DELETE CASCADE,
+  owner_id TEXT NOT NULL,
+  storage_key TEXT NOT NULL UNIQUE,
+  media_type TEXT NOT NULL CHECK (media_type IN ('image', 'audio')),
+  mime_type TEXT NOT NULL,
+  byte_size INTEGER NOT NULL CHECK (byte_size > 0 AND byte_size <= 104857600),
+  position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX capsule_media_capsule_id_position_idx ON capsule_media (capsule_id, position);

--- a/lib/auth/user.ts
+++ b/lib/auth/user.ts
@@ -1,0 +1,13 @@
+const DEV_USER_HEADER = "x-user-id";
+
+export function getAuthenticatedUserId(request: { headers: Headers }): string | null {
+  if (
+    process.env.NODE_ENV !== "production" &&
+    process.env.CAPSULE_ENABLE_DEV_USER_HEADER === "true"
+  ) {
+    const userId = request.headers.get(DEV_USER_HEADER)?.trim();
+    return userId || null;
+  }
+
+  return null;
+}

--- a/lib/capsules/http.ts
+++ b/lib/capsules/http.ts
@@ -1,0 +1,66 @@
+import {
+  type Capsule,
+  type CapsuleCreateInput,
+  canReadCapsuleContent,
+  canReadCapsuleMetadata,
+  getCapsuleState,
+} from "./model";
+
+export type CapsuleResponse = {
+  id: string;
+  ownerId: string;
+  title: string;
+  body?: string;
+  visibility: Capsule["visibility"];
+  state: ReturnType<typeof getCapsuleState>;
+  canOpen: boolean;
+  openAt: string;
+  openedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  mediaCount: number;
+  mediaTotalBytes: number;
+};
+
+type CapsuleRequestBody = {
+  title?: unknown;
+  body?: unknown;
+  openAt?: unknown;
+  visibility?: unknown;
+};
+
+export function requesterIdFromHeaders(headers: Headers): string | undefined {
+  return headers.get("x-user-id")?.trim() || undefined;
+}
+
+export function parseCapsuleCreateBody(payload: CapsuleRequestBody, ownerId: string): CapsuleCreateInput {
+  return {
+    ownerId,
+    title: typeof payload.title === "string" ? payload.title : "",
+    body: typeof payload.body === "string" ? payload.body : "",
+    openAt: typeof payload.openAt === "string" ? new Date(payload.openAt) : new Date(Number.NaN),
+    visibility: payload.visibility === "public" ? "public" : payload.visibility === "private" ? "private" : undefined,
+  };
+}
+
+export function toCapsuleResponse(capsule: Capsule, requesterId?: string, now = new Date()): CapsuleResponse {
+  return {
+    id: capsule.id,
+    ownerId: capsule.ownerId,
+    title: capsule.title,
+    ...(canReadCapsuleContent(capsule, { requesterId, now }) ? { body: capsule.body } : {}),
+    visibility: capsule.visibility,
+    state: getCapsuleState(capsule),
+    canOpen: capsule.ownerId === requesterId && !capsule.openedAt && capsule.openAt <= now,
+    openAt: capsule.openAt.toISOString(),
+    openedAt: capsule.openedAt?.toISOString() ?? null,
+    createdAt: capsule.createdAt.toISOString(),
+    updatedAt: capsule.updatedAt.toISOString(),
+    mediaCount: capsule.mediaCount,
+    mediaTotalBytes: capsule.mediaTotalBytes,
+  };
+}
+
+export function filterReadableCapsules(capsules: Capsule[], requesterId?: string): Capsule[] {
+  return capsules.filter((capsule) => canReadCapsuleMetadata(capsule, { requesterId }));
+}

--- a/lib/capsules/http.ts
+++ b/lib/capsules/http.ts
@@ -5,6 +5,7 @@ import {
   canReadCapsuleMetadata,
   getCapsuleState,
 } from "./model";
+import { getAuthenticatedUserId } from "@/lib/auth/user";
 
 export type CapsuleResponse = {
   id: string;
@@ -29,8 +30,8 @@ type CapsuleRequestBody = {
   visibility?: unknown;
 };
 
-export function requesterIdFromHeaders(headers: Headers): string | undefined {
-  return headers.get("x-user-id")?.trim() || undefined;
+export function requesterIdFromHeaders(headers: Headers): string | null {
+  return getAuthenticatedUserId({ headers });
 }
 
 export function parseCapsuleCreateBody(payload: CapsuleRequestBody, ownerId: string): CapsuleCreateInput {
@@ -43,7 +44,7 @@ export function parseCapsuleCreateBody(payload: CapsuleRequestBody, ownerId: str
   };
 }
 
-export function toCapsuleResponse(capsule: Capsule, requesterId?: string, now = new Date()): CapsuleResponse {
+export function toCapsuleResponse(capsule: Capsule, requesterId: string | null, now = new Date()): CapsuleResponse {
   return {
     id: capsule.id,
     ownerId: capsule.ownerId,
@@ -61,6 +62,6 @@ export function toCapsuleResponse(capsule: Capsule, requesterId?: string, now = 
   };
 }
 
-export function filterReadableCapsules(capsules: Capsule[], requesterId?: string): Capsule[] {
+export function filterReadableCapsules(capsules: Capsule[], requesterId: string | null): Capsule[] {
   return capsules.filter((capsule) => canReadCapsuleMetadata(capsule, { requesterId }));
 }

--- a/lib/capsules/http.ts
+++ b/lib/capsules/http.ts
@@ -28,6 +28,8 @@ type CapsuleRequestBody = {
   body?: unknown;
   openAt?: unknown;
   visibility?: unknown;
+  mediaCount?: unknown;
+  mediaTotalBytes?: unknown;
 };
 
 export function requesterIdFromHeaders(headers: Headers): string | null {
@@ -40,7 +42,19 @@ export function parseCapsuleCreateBody(payload: CapsuleRequestBody, ownerId: str
     title: typeof payload.title === "string" ? payload.title : "",
     body: typeof payload.body === "string" ? payload.body : "",
     openAt: typeof payload.openAt === "string" ? new Date(payload.openAt) : new Date(Number.NaN),
-    visibility: payload.visibility === "public" ? "public" : payload.visibility === "private" ? "private" : undefined,
+    visibility: typeof payload.visibility === "string" ? payload.visibility : undefined,
+    mediaCount:
+      payload.mediaCount === undefined
+        ? undefined
+        : typeof payload.mediaCount === "number"
+          ? payload.mediaCount
+          : Number.NaN,
+    mediaTotalBytes:
+      payload.mediaTotalBytes === undefined
+        ? undefined
+        : typeof payload.mediaTotalBytes === "number"
+          ? payload.mediaTotalBytes
+          : Number.NaN,
   };
 }
 

--- a/lib/capsules/model.ts
+++ b/lib/capsules/model.ts
@@ -1,0 +1,183 @@
+export const CAPSULE_VISIBILITIES = ["private", "public"] as const;
+
+export type CapsuleVisibility = (typeof CAPSULE_VISIBILITIES)[number];
+
+export type CapsuleState = "locked" | "opened";
+
+export type Capsule = {
+  id: string;
+  ownerId: string;
+  title: string;
+  body: string;
+  visibility: CapsuleVisibility;
+  openAt: Date;
+  openedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  mediaCount: number;
+  mediaTotalBytes: number;
+};
+
+export type CapsuleCreateInput = {
+  ownerId: string;
+  title: string;
+  body: string;
+  openAt: Date;
+  visibility?: CapsuleVisibility;
+  mediaCount?: number;
+  mediaTotalBytes?: number;
+};
+
+export type CapsuleAccessContext = {
+  requesterId?: string;
+  now?: Date;
+};
+
+export const CAPSULE_LIMITS = {
+  titleMaxLength: 120,
+  bodyMaxLength: 10000,
+  mediaMaxItems: 12,
+  mediaMaxTotalBytes: 100 * 1024 * 1024,
+} as const;
+
+export class CapsuleValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CapsuleValidationError";
+  }
+}
+
+export class CapsuleAccessError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CapsuleAccessError";
+  }
+}
+
+export function getCapsuleState(capsule: Pick<Capsule, "openedAt">): CapsuleState {
+  return capsule.openedAt ? "opened" : "locked";
+}
+
+export function isCapsuleOwner(
+  capsule: Pick<Capsule, "ownerId">,
+  requesterId?: string,
+): boolean {
+  return Boolean(requesterId && capsule.ownerId === requesterId);
+}
+
+export function canOpenCapsule(
+  capsule: Pick<Capsule, "ownerId" | "openAt" | "openedAt">,
+  { requesterId, now = new Date() }: CapsuleAccessContext,
+): boolean {
+  return isCapsuleOwner(capsule, requesterId) && !capsule.openedAt && capsule.openAt <= now;
+}
+
+export function canReadCapsuleMetadata(
+  capsule: Pick<Capsule, "ownerId" | "visibility" | "openedAt">,
+  { requesterId }: CapsuleAccessContext,
+): boolean {
+  return isCapsuleOwner(capsule, requesterId) || (capsule.visibility === "public" && Boolean(capsule.openedAt));
+}
+
+export function canReadCapsuleContent(
+  capsule: Pick<Capsule, "ownerId" | "visibility" | "openedAt">,
+  { requesterId }: CapsuleAccessContext,
+): boolean {
+  if (!capsule.openedAt) {
+    return false;
+  }
+
+  if (capsule.visibility === "public") {
+    return true;
+  }
+
+  return isCapsuleOwner(capsule, requesterId);
+}
+
+export function assertValidCapsuleCreateInput(input: CapsuleCreateInput, now = new Date()): void {
+  if (!input.ownerId.trim()) {
+    throw new CapsuleValidationError("ownerId is required");
+  }
+
+  if (!input.title.trim()) {
+    throw new CapsuleValidationError("title is required");
+  }
+
+  if (input.title.length > CAPSULE_LIMITS.titleMaxLength) {
+    throw new CapsuleValidationError(`title must be ${CAPSULE_LIMITS.titleMaxLength} characters or fewer`);
+  }
+
+  if (!input.body.trim()) {
+    throw new CapsuleValidationError("body is required");
+  }
+
+  if (input.body.length > CAPSULE_LIMITS.bodyMaxLength) {
+    throw new CapsuleValidationError(`body must be ${CAPSULE_LIMITS.bodyMaxLength} characters or fewer`);
+  }
+
+  if (Number.isNaN(input.openAt.getTime())) {
+    throw new CapsuleValidationError("openAt must be a valid date");
+  }
+
+  if (input.openAt <= now) {
+    throw new CapsuleValidationError("openAt must be in the future");
+  }
+
+  if (input.visibility && !CAPSULE_VISIBILITIES.includes(input.visibility)) {
+    throw new CapsuleValidationError("visibility must be private or public");
+  }
+
+  const mediaCount = input.mediaCount ?? 0;
+  const mediaTotalBytes = input.mediaTotalBytes ?? 0;
+
+  if (!Number.isInteger(mediaCount) || mediaCount < 0 || mediaCount > CAPSULE_LIMITS.mediaMaxItems) {
+    throw new CapsuleValidationError(`mediaCount must be between 0 and ${CAPSULE_LIMITS.mediaMaxItems}`);
+  }
+
+  if (
+    !Number.isInteger(mediaTotalBytes) ||
+    mediaTotalBytes < 0 ||
+    mediaTotalBytes > CAPSULE_LIMITS.mediaMaxTotalBytes
+  ) {
+    throw new CapsuleValidationError(
+      `mediaTotalBytes must be between 0 and ${CAPSULE_LIMITS.mediaMaxTotalBytes}`,
+    );
+  }
+}
+
+export function createCapsuleRecord(
+  id: string,
+  input: CapsuleCreateInput,
+  now = new Date(),
+): Capsule {
+  assertValidCapsuleCreateInput(input, now);
+
+  return {
+    id,
+    ownerId: input.ownerId,
+    title: input.title.trim(),
+    body: input.body.trim(),
+    visibility: input.visibility ?? "private",
+    openAt: input.openAt,
+    openedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    mediaCount: input.mediaCount ?? 0,
+    mediaTotalBytes: input.mediaTotalBytes ?? 0,
+  };
+}
+
+export function openCapsule(
+  capsule: Capsule,
+  { requesterId, now = new Date() }: CapsuleAccessContext,
+): Capsule {
+  if (!canOpenCapsule(capsule, { requesterId, now })) {
+    throw new CapsuleAccessError("capsule can only be opened by its owner on or after openAt");
+  }
+
+  return {
+    ...capsule,
+    openedAt: now,
+    updatedAt: now,
+  };
+}

--- a/lib/capsules/model.ts
+++ b/lib/capsules/model.ts
@@ -23,7 +23,7 @@ export type CapsuleCreateInput = {
   title: string;
   body: string;
   openAt: Date;
-  visibility?: CapsuleVisibility;
+  visibility?: CapsuleVisibility | string;
   mediaCount?: number;
   mediaTotalBytes?: number;
 };
@@ -123,7 +123,7 @@ export function assertValidCapsuleCreateInput(input: CapsuleCreateInput, now = n
     throw new CapsuleValidationError("openAt must be in the future");
   }
 
-  if (input.visibility && !CAPSULE_VISIBILITIES.includes(input.visibility)) {
+  if (input.visibility && !CAPSULE_VISIBILITIES.includes(input.visibility as CapsuleVisibility)) {
     throw new CapsuleValidationError("visibility must be private or public");
   }
 
@@ -151,13 +151,14 @@ export function createCapsuleRecord(
   now = new Date(),
 ): Capsule {
   assertValidCapsuleCreateInput(input, now);
+  const visibility = input.visibility ?? "private";
 
   return {
     id,
     ownerId: input.ownerId,
     title: input.title.trim(),
     body: input.body.trim(),
-    visibility: input.visibility ?? "private",
+    visibility: visibility as CapsuleVisibility,
     openAt: input.openAt,
     openedAt: null,
     createdAt: now,

--- a/lib/capsules/model.ts
+++ b/lib/capsules/model.ts
@@ -29,7 +29,7 @@ export type CapsuleCreateInput = {
 };
 
 export type CapsuleAccessContext = {
-  requesterId?: string;
+  requesterId: string | null;
   now?: Date;
 };
 
@@ -60,7 +60,7 @@ export function getCapsuleState(capsule: Pick<Capsule, "openedAt">): CapsuleStat
 
 export function isCapsuleOwner(
   capsule: Pick<Capsule, "ownerId">,
-  requesterId?: string,
+  requesterId: string | null,
 ): boolean {
   return Boolean(requesterId && capsule.ownerId === requesterId);
 }

--- a/lib/capsules/repository.ts
+++ b/lib/capsules/repository.ts
@@ -1,0 +1,41 @@
+import { randomUUID } from "node:crypto";
+import {
+  type Capsule,
+  type CapsuleCreateInput,
+  createCapsuleRecord,
+  openCapsule,
+} from "./model";
+
+type StoredCapsules = Map<string, Capsule>;
+
+const capsules: StoredCapsules = new Map();
+
+export function createCapsule(input: CapsuleCreateInput, now = new Date()): Capsule {
+  const capsule = createCapsuleRecord(randomUUID(), input, now);
+  capsules.set(capsule.id, capsule);
+  return capsule;
+}
+
+export function getCapsuleById(id: string): Capsule | null {
+  return capsules.get(id) ?? null;
+}
+
+export function listCapsules(): Capsule[] {
+  return Array.from(capsules.values()).sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+}
+
+export function markCapsuleOpened(id: string, requesterId: string, now = new Date()): Capsule | null {
+  const capsule = getCapsuleById(id);
+
+  if (!capsule) {
+    return null;
+  }
+
+  const opened = openCapsule(capsule, { requesterId, now });
+  capsules.set(opened.id, opened);
+  return opened;
+}
+
+export function clearCapsulesForTests(): void {
+  capsules.clear();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "postcss": "^8",
         "prettier": "^3",
         "tailwindcss": "^3.4.1",
+        "tsx": "^4.22.4",
         "typescript": "^5"
       }
     },
@@ -70,6 +71,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2658,6 +3101,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -4285,9 +4770,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -4742,9 +5227,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -4762,7 +5247,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5788,9 +6273,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5886,6 +6371,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test": "tsx --test tests/**/*.test.ts",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
@@ -17,15 +18,16 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
-    "autoprefixer": "^10",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "autoprefixer": "^10",
     "eslint": "^9",
     "eslint-config-next": "15.5.15",
     "postcss": "^8",
     "prettier": "^3",
     "tailwindcss": "^3.4.1",
+    "tsx": "^4.22.4",
     "typescript": "^5"
   }
 }

--- a/tests/auth/user.test.ts
+++ b/tests/auth/user.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { getAuthenticatedUserId } from "@/lib/auth/user";
+
+const originalNodeEnv = process.env.NODE_ENV;
+const originalDevHeaderFlag = process.env.CAPSULE_ENABLE_DEV_USER_HEADER;
+
+function requestWithUserHeader(userId: string) {
+  return new Request("http://localhost/api/capsules", {
+    headers: { "x-user-id": userId },
+  });
+}
+
+afterEach(() => {
+  process.env["NODE_ENV"] = originalNodeEnv;
+
+  if (originalDevHeaderFlag === undefined) {
+    delete process.env.CAPSULE_ENABLE_DEV_USER_HEADER;
+  } else {
+    process.env.CAPSULE_ENABLE_DEV_USER_HEADER = originalDevHeaderFlag;
+  }
+});
+
+describe("getAuthenticatedUserId", () => {
+  it("does not trust x-user-id by default", () => {
+    delete process.env.CAPSULE_ENABLE_DEV_USER_HEADER;
+
+    assert.equal(getAuthenticatedUserId(requestWithUserHeader("user-1")), null);
+  });
+
+  it("allows x-user-id only when explicitly enabled outside production", () => {
+    process.env["NODE_ENV"] = "development";
+    process.env.CAPSULE_ENABLE_DEV_USER_HEADER = "true";
+
+    assert.equal(getAuthenticatedUserId(requestWithUserHeader("user-1")), "user-1");
+  });
+
+  it("does not allow x-user-id in production even when the dev flag is set", () => {
+    process.env["NODE_ENV"] = "production";
+    process.env.CAPSULE_ENABLE_DEV_USER_HEADER = "true";
+
+    assert.equal(getAuthenticatedUserId(requestWithUserHeader("user-1")), null);
+  });
+});

--- a/tests/capsules/http.test.ts
+++ b/tests/capsules/http.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  filterReadableCapsules,
+  parseCapsuleCreateBody,
+  toCapsuleResponse,
+} from "@/lib/capsules/http";
+import { createCapsuleRecord, openCapsule } from "@/lib/capsules/model";
+
+const now = new Date("2026-06-08T12:00:00.000Z");
+const future = new Date("2026-06-09T12:00:00.000Z");
+const openedAt = new Date("2026-06-09T12:00:01.000Z");
+
+function createTestCapsule(overrides = {}, id = "capsule-1") {
+  return createCapsuleRecord(
+    id,
+    {
+      ownerId: "user-1",
+      title: "Future note",
+      body: "Remember this.",
+      openAt: future,
+      visibility: "private",
+      ...overrides,
+    },
+    now,
+  );
+}
+
+describe("capsule HTTP helpers", () => {
+  it("parses create payload fields used by the domain model", () => {
+    const input = parseCapsuleCreateBody(
+      {
+        title: " Future note ",
+        body: " Remember this. ",
+        openAt: future.toISOString(),
+        visibility: "public",
+        mediaCount: 2,
+        mediaTotalBytes: 1024,
+      },
+      "user-1",
+    );
+
+    assert.equal(input.ownerId, "user-1");
+    assert.equal(input.title, " Future note ");
+    assert.equal(input.body, " Remember this. ");
+    assert.equal(input.openAt.toISOString(), future.toISOString());
+    assert.equal(input.visibility, "public");
+    assert.equal(input.mediaCount, 2);
+    assert.equal(input.mediaTotalBytes, 1024);
+  });
+
+  it("passes invalid visibility and media metadata through for validation", () => {
+    const input = parseCapsuleCreateBody(
+      {
+        title: "Future note",
+        body: "Remember this.",
+        openAt: future.toISOString(),
+        visibility: "shared",
+        mediaCount: "2",
+        mediaTotalBytes: "1024",
+      },
+      "user-1",
+    );
+
+    assert.equal(input.visibility, "shared");
+    assert.equal(Number.isNaN(input.mediaCount), true);
+    assert.equal(Number.isNaN(input.mediaTotalBytes), true);
+  });
+
+  it("hides content while locked and includes it only when readable", () => {
+    const locked = createTestCapsule({ visibility: "public" });
+    const openedPublic = openCapsule(locked, { requesterId: "user-1", now: openedAt });
+    const openedPrivate = openCapsule(createTestCapsule(), { requesterId: "user-1", now: openedAt });
+
+    assert.equal("body" in toCapsuleResponse(locked, "user-1", now), false);
+    assert.equal(toCapsuleResponse(openedPublic, null, openedAt).body, "Remember this.");
+    assert.equal("body" in toCapsuleResponse(openedPrivate, "user-2", openedAt), false);
+    assert.equal(toCapsuleResponse(openedPrivate, "user-1", openedAt).body, "Remember this.");
+  });
+
+  it("filters readable capsule metadata by owner, visibility, and opened state", () => {
+    const lockedPublic = createTestCapsule({ visibility: "public" }, "locked-public");
+    const openedPublic = openCapsule(createTestCapsule({ visibility: "public" }, "opened-public"), {
+      requesterId: "user-1",
+      now: openedAt,
+    });
+    const openedPrivate = openCapsule(createTestCapsule({}, "opened-private"), {
+      requesterId: "user-1",
+      now: openedAt,
+    });
+
+    assert.deepEqual(
+      filterReadableCapsules([lockedPublic, openedPublic, openedPrivate], "user-2").map(
+        (capsule) => capsule.id,
+      ),
+      ["opened-public"],
+    );
+    assert.deepEqual(
+      filterReadableCapsules([lockedPublic, openedPublic, openedPrivate], "user-1").map(
+        (capsule) => capsule.id,
+      ),
+      ["locked-public", "opened-public", "opened-private"],
+    );
+  });
+});

--- a/tests/capsules/model.test.ts
+++ b/tests/capsules/model.test.ts
@@ -86,6 +86,16 @@ describe("capsule model", () => {
 
     assert.equal(canReadCapsuleMetadata(publicCapsule, { requesterId: "user-2" }), true);
     assert.equal(canReadCapsuleContent(publicCapsule, { requesterId: "user-2" }), true);
-    assert.equal(canReadCapsuleContent(publicCapsule, {}), true);
+    assert.equal(canReadCapsuleContent(publicCapsule, { requesterId: null }), true);
+  });
+
+  it("denies unauthenticated requesters private and locked capsule access", () => {
+    const lockedPublicCapsule = createTestCapsule({ visibility: "public" });
+    const openedPrivateCapsule = openCapsule(createTestCapsule(), { requesterId: "user-1", now: afterFuture });
+
+    assert.equal(canReadCapsuleMetadata(lockedPublicCapsule, { requesterId: null }), false);
+    assert.equal(canReadCapsuleContent(lockedPublicCapsule, { requesterId: null }), false);
+    assert.equal(canReadCapsuleMetadata(openedPrivateCapsule, { requesterId: null }), false);
+    assert.equal(canReadCapsuleContent(openedPrivateCapsule, { requesterId: null }), false);
   });
 });

--- a/tests/capsules/model.test.ts
+++ b/tests/capsules/model.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  CapsuleAccessError,
+  CapsuleValidationError,
+  canReadCapsuleContent,
+  canReadCapsuleMetadata,
+  createCapsuleRecord,
+  getCapsuleState,
+  openCapsule,
+} from "@/lib/capsules/model";
+
+const now = new Date("2026-06-08T12:00:00.000Z");
+const future = new Date("2026-06-09T12:00:00.000Z");
+const afterFuture = new Date("2026-06-09T12:00:01.000Z");
+
+function createTestCapsule(overrides = {}) {
+  return createCapsuleRecord(
+    "capsule-1",
+    {
+      ownerId: "user-1",
+      title: "Future note",
+      body: "Remember this.",
+      openAt: future,
+      visibility: "private",
+      ...overrides,
+    },
+    now,
+  );
+}
+
+describe("capsule model", () => {
+  it("creates locked private capsules with validated fields", () => {
+    const capsule = createTestCapsule();
+
+    assert.equal(capsule.ownerId, "user-1");
+    assert.equal(capsule.visibility, "private");
+    assert.equal(capsule.openedAt, null);
+    assert.equal(getCapsuleState(capsule), "locked");
+    assert.equal(capsule.mediaCount, 0);
+    assert.equal(capsule.mediaTotalBytes, 0);
+  });
+
+  it("requires openAt to be in the future", () => {
+    assert.throws(
+      () => createTestCapsule({ openAt: now }),
+      (error) => error instanceof CapsuleValidationError && error.message === "openAt must be in the future",
+    );
+  });
+
+  it("only allows the owner to open a capsule on or after openAt", () => {
+    const capsule = createTestCapsule();
+
+    assert.throws(
+      () => openCapsule(capsule, { requesterId: "user-1", now }),
+      (error) => error instanceof CapsuleAccessError,
+    );
+    assert.throws(
+      () => openCapsule(capsule, { requesterId: "user-2", now: afterFuture }),
+      (error) => error instanceof CapsuleAccessError,
+    );
+
+    const opened = openCapsule(capsule, { requesterId: "user-1", now: afterFuture });
+    assert.equal(getCapsuleState(opened), "opened");
+    assert.equal(opened.openedAt?.toISOString(), afterFuture.toISOString());
+  });
+
+  it("keeps locked capsule content private even when visibility is public", () => {
+    const capsule = createTestCapsule({ visibility: "public" });
+
+    assert.equal(canReadCapsuleMetadata(capsule, { requesterId: "user-2" }), false);
+    assert.equal(canReadCapsuleContent(capsule, { requesterId: "user-1" }), false);
+    assert.equal(canReadCapsuleContent(capsule, { requesterId: "user-2" }), false);
+  });
+
+  it("allows anyone to read opened public capsules and only owners to read opened private capsules", () => {
+    const privateCapsule = openCapsule(createTestCapsule(), { requesterId: "user-1", now: afterFuture });
+    const publicCapsule = openCapsule(createTestCapsule({ visibility: "public" }), {
+      requesterId: "user-1",
+      now: afterFuture,
+    });
+
+    assert.equal(canReadCapsuleMetadata(privateCapsule, { requesterId: "user-2" }), false);
+    assert.equal(canReadCapsuleContent(privateCapsule, { requesterId: "user-2" }), false);
+    assert.equal(canReadCapsuleContent(privateCapsule, { requesterId: "user-1" }), true);
+
+    assert.equal(canReadCapsuleMetadata(publicCapsule, { requesterId: "user-2" }), true);
+    assert.equal(canReadCapsuleContent(publicCapsule, { requesterId: "user-2" }), true);
+    assert.equal(canReadCapsuleContent(publicCapsule, {}), true);
+  });
+});

--- a/tests/capsules/model.test.ts
+++ b/tests/capsules/model.test.ts
@@ -48,6 +48,23 @@ describe("capsule model", () => {
     );
   });
 
+  it("rejects invalid visibility and media metadata", () => {
+    assert.throws(
+      () => createTestCapsule({ visibility: "shared" }),
+      (error) => error instanceof CapsuleValidationError && error.message === "visibility must be private or public",
+    );
+    assert.throws(
+      () => createTestCapsule({ mediaCount: 13 }),
+      (error) => error instanceof CapsuleValidationError && error.message === "mediaCount must be between 0 and 12",
+    );
+    assert.throws(
+      () => createTestCapsule({ mediaTotalBytes: 104857601 }),
+      (error) =>
+        error instanceof CapsuleValidationError &&
+        error.message === "mediaTotalBytes must be between 0 and 104857600",
+    );
+  });
+
   it("only allows the owner to open a capsule on or after openAt", () => {
     const capsule = createTestCapsule();
 

--- a/tests/capsules/repository.test.ts
+++ b/tests/capsules/repository.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import {
+  clearCapsulesForTests,
+  createCapsule,
+  getCapsuleById,
+  listCapsules,
+  markCapsuleOpened,
+} from "@/lib/capsules/repository";
+
+const now = new Date("2026-06-08T12:00:00.000Z");
+const future = new Date("2026-06-09T12:00:00.000Z");
+const openedAt = new Date("2026-06-09T12:00:01.000Z");
+
+afterEach(() => {
+  clearCapsulesForTests();
+});
+
+function createTestCapsule(ownerId = "user-1") {
+  return createCapsule(
+    {
+      ownerId,
+      title: "Future note",
+      body: "Remember this.",
+      openAt: future,
+      visibility: "private",
+    },
+    now,
+  );
+}
+
+describe("capsule repository", () => {
+  it("stores created capsules and returns newest first", () => {
+    const older = createTestCapsule("user-1");
+    const newer = createCapsule(
+      {
+        ownerId: "user-2",
+        title: "Later note",
+        body: "Remember this too.",
+        openAt: future,
+        visibility: "public",
+      },
+      new Date("2026-06-08T12:00:01.000Z"),
+    );
+
+    assert.equal(getCapsuleById(older.id)?.id, older.id);
+    assert.deepEqual(
+      listCapsules().map((capsule) => capsule.id),
+      [newer.id, older.id],
+    );
+  });
+
+  it("marks an existing capsule opened through the domain rules", () => {
+    const capsule = createTestCapsule();
+
+    const opened = markCapsuleOpened(capsule.id, "user-1", openedAt);
+
+    assert.equal(opened?.openedAt?.toISOString(), openedAt.toISOString());
+    assert.equal(getCapsuleById(capsule.id)?.openedAt?.toISOString(), openedAt.toISOString());
+  });
+
+  it("returns null when opening a missing capsule", () => {
+    assert.equal(markCapsuleOpened("missing", "user-1", openedAt), null);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the core capsule backend model, in-memory repository, migration, and API routes for create/list/read/open flows.
- Defines locked versus opened state from `openedAt`, owner-only opening on or after `openAt`, and private/public read rules where public capsules become readable only after opening.
- Reserves media support constraints through `mediaCount`, `mediaTotalBytes`, and `capsule_media` schema limits, with request validation coverage for invalid values.

## Verification
- `npm test`
- `npm run lint`
- `npm run build`