### PR TITLE
feat: add app header + layout shell (closes #33)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Header from "@/components/Header";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -13,7 +14,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body className="min-h-screen bg-gray-50 text-gray-900">
+        <Header />
+        <main className="mx-auto max-w-5xl px-6 py-8">{children}</main>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,18 @@
+import Link from "next/link";
+
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold tracking-tight text-foreground">
-          Capsule
-        </h1>
-        <p className="mt-4 text-lg text-gray-600 dark:text-gray-400">
-          Capture moments. Revisit memories.
-        </p>
-      </div>
-    </main>
+    <section className="flex flex-col items-start gap-4 py-10">
+      <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+        Capsule
+      </h1>
+      <p className="text-base text-gray-600">Seal a memory. Open it later.</p>
+      <Link
+        href="/capsules/new"
+        className="inline-flex items-center rounded-md border border-gray-900 bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800"
+      >
+        Start a capsule →
+      </Link>
+    </section>
   );
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+type NavLink = { href: string; label: string };
+
+const NAV_LINKS: NavLink[] = [
+  { href: "/capsules/new", label: "New capsule" },
+  { href: "/capsules", label: "All capsules" },
+];
+
+function isActive(pathname: string, href: string): boolean {
+  if (href === "/") return pathname === "/";
+  if (pathname === href) return true;
+  return pathname.startsWith(href + "/");
+}
+
+export default function Header() {
+  const pathname = usePathname();
+  return (
+    <header className="border-b border-gray-200 bg-white">
+      <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+        <Link
+          href="/"
+          className="text-lg font-semibold tracking-tight text-gray-900"
+        >
+          Capsule
+        </Link>
+        <nav aria-label="Primary">
+          <ul className="flex items-center gap-6 text-sm">
+            {NAV_LINKS.map(({ href, label }) => {
+              const active = isActive(pathname, href);
+              return (
+                <li key={href}>
+                  <Link
+                    href={href}
+                    aria-current={active ? "page" : undefined}
+                    className={
+                      active
+                        ? "font-semibold text-gray-900 underline underline-offset-4"
+                        : "text-gray-600 hover:text-gray-900"
+                    }
+                  >
+                    {label}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the app layout shell required by issue #33:

- **\`components/Header.tsx\`** — client component using \`usePathname()\` for active-route detection. Brand → \`/\`, two nav links (\`/capsules/new\`, \`/capsules\`). Active link gets \`aria-current="page"\` plus \`font-semibold underline\` styling. Tailwind utilities only.
- **\`app/layout.tsx\`** — mounts \`<Header />\` above \`{children}\` inside a \`<main className="mx-auto max-w-5xl px-6 py-8">\` wrapper.
- **\`app/page.tsx\`** — thin homepage with a "Start a capsule →" CTA pointing to \`/capsules/new\`.

No new runtime dependencies; no new dev-deps. Build passes (\`npm run build\` green).

## What's not in scope (per the issue)

Theme toggle, mobile drawer nav, footer, auth surface, \`/capsules\` page implementation. Those are tracked separately.

## Test plan

- [x] \`npm run build\` passes
- [ ] Vitest + Testing Library tests for \`<Header />\` — deferred to a follow-up alongside the first \`/capsules\` page so the dev-deps land with content that actually exercises them
- [ ] Manual: visit \`/\` — see header with brand, two nav links, and the CTA. Click "All capsules" → 404 (page doesn't exist yet), but the header's active link state should update.

Closes #33