### PR TITLE
feat(capsules): add /capsules/[id] detail page with locked/unlocked states

### DIFF
--- a/app/capsules/[id]/__tests__/page.test.tsx
+++ b/app/capsules/[id]/__tests__/page.test.tsx
@@ -1,0 +1,149 @@
+import { Suspense } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { STORAGE_KEY, type Capsule } from "@/lib/capsule";
+
+const pushMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+import CapsuleDetailPage from "../page";
+
+function seed(capsules: Capsule[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(capsules));
+}
+
+const LOCKED: Capsule = {
+  id: "locked-1",
+  title: "Locked Capsule",
+  body: "secret-body-should-not-appear",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  unlockAt: "2999-01-01T00:00:00.000Z",
+  openedAt: null,
+};
+
+const UNLOCKED_UNOPENED: Capsule = {
+  id: "unlocked-1",
+  title: "Unlocked Capsule",
+  body: "this is the reveal",
+  createdAt: "2020-01-01T00:00:00.000Z",
+  unlockAt: "2020-06-01T00:00:00.000Z",
+  openedAt: null,
+};
+
+beforeEach(() => {
+  pushMock.mockReset();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function resolvedParams(id: string): Promise<{ id: string }> {
+  const value = { id };
+  const p = Promise.resolve(value) as Promise<{ id: string }> & {
+    status: "fulfilled";
+    value: { id: string };
+  };
+  p.status = "fulfilled";
+  p.value = value;
+  return p;
+}
+
+function renderDetail(id: string) {
+  return render(
+    <Suspense fallback={null}>
+      <CapsuleDetailPage params={resolvedParams(id)} />
+    </Suspense>,
+  );
+}
+
+describe("CapsuleDetailPage", () => {
+  it("renders a not-found state with a link back to /capsules when the id is unknown", async () => {
+    renderDetail("missing-id");
+
+    await screen.findByText(/capsule not found/i);
+    const link = screen.getByRole("link", { name: /back to all capsules/i });
+    expect(link).toHaveAttribute("href", "/capsules");
+  });
+
+  it("locked: hides the body, shows the countdown and locked hint", async () => {
+    seed([LOCKED]);
+
+    renderDetail(LOCKED.id);
+
+    await screen.findByText(LOCKED.title);
+    expect(
+      screen.queryByText(LOCKED.body),
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/time until unlock/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/reveal itself when the timer hits zero/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /open capsule/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("unlocked + not opened: shows the body and the Open capsule button", async () => {
+    seed([UNLOCKED_UNOPENED]);
+
+    renderDetail(UNLOCKED_UNOPENED.id);
+
+    await screen.findByText(UNLOCKED_UNOPENED.title);
+    expect(screen.getByText(UNLOCKED_UNOPENED.body)).toBeInTheDocument();
+    expect(screen.getByText(/sealed on/i)).toBeInTheDocument();
+    expect(screen.getByText(/unlocked on/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /open capsule/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("clicking Open capsule transitions to the opened state and persists openedAt", async () => {
+    const user = userEvent.setup();
+    seed([UNLOCKED_UNOPENED]);
+
+    renderDetail(UNLOCKED_UNOPENED.id);
+
+    const openBtn = await screen.findByRole("button", {
+      name: /open capsule/i,
+    });
+    await user.click(openBtn);
+
+    expect(
+      screen.queryByRole("button", { name: /open capsule/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/opened/i)).toBeInTheDocument();
+
+    const stored = JSON.parse(
+      localStorage.getItem(STORAGE_KEY) ?? "[]",
+    ) as Capsule[];
+    expect(stored[0].openedAt).not.toBeNull();
+  });
+
+  it("delete confirmation removes the capsule and navigates back to /capsules", async () => {
+    const user = userEvent.setup();
+    seed([UNLOCKED_UNOPENED]);
+
+    renderDetail(UNLOCKED_UNOPENED.id);
+
+    await screen.findByText(UNLOCKED_UNOPENED.title);
+    await user.click(screen.getByRole("button", { name: /^delete$/i }));
+
+    const dialog = await screen.findByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: /^delete$/i }),
+    );
+
+    expect(pushMock).toHaveBeenCalledWith("/capsules");
+
+    const stored = JSON.parse(
+      localStorage.getItem(STORAGE_KEY) ?? "[]",
+    ) as Capsule[];
+    expect(stored).toEqual([]);
+  });
+});

--- a/app/capsules/[id]/page.tsx
+++ b/app/capsules/[id]/page.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { use, useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  deleteCapsule,
+  getCapsule,
+  isUnlocked,
+  markOpened,
+  type Capsule,
+} from "@/lib/capsule";
+import { formatCountdown, formatUnlockDate } from "@/lib/capsule-format";
+
+type PageProps = { params: Promise<{ id: string }> };
+
+type LoadState = "loading" | "loaded";
+
+export default function CapsuleDetailPage({ params }: PageProps) {
+  const { id } = use(params);
+  const router = useRouter();
+  const [capsule, setCapsule] = useState<Capsule | null>(null);
+  const [loadState, setLoadState] = useState<LoadState>("loading");
+  const [now, setNow] = useState<number>(() => Date.now());
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  useEffect(() => {
+    setCapsule(getCapsule(id));
+    setLoadState("loaded");
+  }, [id]);
+
+  useEffect(() => {
+    if (capsule === null) return;
+    if (isUnlocked(capsule)) return;
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, [capsule]);
+
+  if (loadState === "loading") return null;
+
+  if (capsule === null) {
+    return (
+      <section
+        aria-labelledby="not-found-heading"
+        className="rounded-lg border border-gray-200 bg-white p-8 text-center"
+      >
+        <h1
+          id="not-found-heading"
+          className="mb-2 text-2xl font-semibold tracking-tight text-gray-900"
+        >
+          Capsule not found
+        </h1>
+        <p className="mb-6 text-gray-600">
+          We couldn’t find a capsule with that id.
+        </p>
+        <Link
+          href="/capsules"
+          className="font-medium text-gray-900 underline underline-offset-4 hover:text-black"
+        >
+          Back to all capsules
+        </Link>
+      </section>
+    );
+  }
+
+  const unlocked = isUnlocked(capsule, new Date(now));
+
+  function handleDelete() {
+    deleteCapsule(id);
+    router.push("/capsules");
+  }
+
+  function handleOpen() {
+    const updated = markOpened(id);
+    if (updated !== null) setCapsule(updated);
+  }
+
+  return (
+    <section aria-labelledby="capsule-heading">
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <h1
+          id="capsule-heading"
+          className="text-2xl font-semibold tracking-tight text-gray-900"
+        >
+          {capsule.title}
+        </h1>
+        <button
+          type="button"
+          onClick={() => setConfirmingDelete(true)}
+          className="shrink-0 rounded-md border border-red-200 px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-50"
+        >
+          Delete
+        </button>
+      </div>
+
+      {!unlocked ? (
+        <div
+          aria-labelledby="locked-heading"
+          className="rounded-xl border border-amber-200 bg-amber-50 p-8 text-center"
+        >
+          <p
+            id="locked-heading"
+            className="text-xs font-semibold uppercase tracking-widest text-amber-700"
+          >
+            Locked
+          </p>
+          <p
+            aria-label="time until unlock"
+            className="my-4 font-mono text-5xl font-semibold tabular-nums text-amber-900"
+          >
+            {formatCountdown(Date.parse(capsule.unlockAt) - now)}
+          </p>
+          <p className="text-sm text-amber-700">
+            This capsule will reveal itself when the timer hits zero.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-6">
+          <article className="whitespace-pre-wrap rounded-lg border border-gray-200 bg-white p-6 text-gray-900">
+            {capsule.body}
+          </article>
+          <dl className="grid gap-3 text-sm text-gray-600 sm:grid-cols-2">
+            <div>
+              <dt className="font-medium text-gray-700">Sealed on</dt>
+              <dd>{formatUnlockDate(capsule.createdAt)}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-gray-700">Unlocked on</dt>
+              <dd>{formatUnlockDate(capsule.unlockAt)}</dd>
+            </div>
+          </dl>
+          {capsule.openedAt === null ? (
+            <button
+              type="button"
+              onClick={handleOpen}
+              className="self-start rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-black"
+            >
+              Open capsule
+            </button>
+          ) : (
+            <p className="text-sm text-gray-500">
+              Opened {formatUnlockDate(capsule.openedAt)}
+            </p>
+          )}
+        </div>
+      )}
+
+      {confirmingDelete && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="confirm-delete-heading"
+          className="fixed inset-0 z-10 flex items-center justify-center bg-black/40 p-4"
+        >
+          <div className="w-full max-w-sm rounded-lg bg-white p-6 shadow-lg">
+            <h2
+              id="confirm-delete-heading"
+              className="text-lg font-semibold text-gray-900"
+            >
+              Delete this capsule?
+            </h2>
+            <p className="mt-2 text-sm text-gray-600">
+              This will permanently remove the capsule. This can’t be undone.
+            </p>
+            <div className="mt-6 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirmingDelete(false)}
+                className="rounded-md border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleDelete}
+                className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-red-700"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #29.

Adds the dynamic `/capsules/[id]` route as a client component (`use(params)`):

- **Not found**: renders a "Capsule not found" panel with a link back to `/capsules` when `getCapsule(id)` returns null.
- **Locked**: shows the title + a live-updating countdown to `unlockAt` (refresh every second), hides the body, and adds a hint that the capsule will reveal itself when the timer hits zero.
- **Unlocked**: shows the body, "Sealed on …" (`createdAt`) and "Unlocked on …" (`unlockAt`). If `openedAt` is null, renders an "Open capsule" button that calls `markOpened(id)` and re-renders into the opened state; otherwise renders "Opened …".
- **Delete**: top-right affordance opens a confirm dialog (`role="dialog"`, `aria-modal`); confirming calls `deleteCapsule(id)` and `router.push('/capsules')`.

Out of scope as required by the issue: media, sharing, comments, edit.

## Test plan

Vitest + Testing Library coverage in `app/capsules/[id]/__tests__/page.test.tsx`:

- [x] Not-found state renders with a `Back to all capsules` link to `/capsules`.
- [x] Locked: body text is not in the DOM; countdown label and hint are present; no Open button.
- [x] Unlocked + not opened: body, "Sealed on", "Unlocked on", and the Open button are present.
- [x] Clicking Open transitions to opened state and persists `openedAt` in localStorage.
- [x] Delete confirm dialog calls `deleteCapsule` (storage becomes empty) and pushes `/capsules`.

Verified locally: `npm test` (25 passed), `npx tsc --noEmit`, `npm run lint`, `npm run build` all green.